### PR TITLE
Make tarball directory version component optional

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -672,6 +672,11 @@ for my $file (@args) {
     for my $entry (list_files($archive, $type)) {
         next if ($type eq 'tar' and $entry eq 'pax_global_header');
 
+        # Try stripping any non-digits from $version on a path failure
+        if ($entry !~ /^(?:.\/)?($name(?:-(?:v\.?)?$version)?)(?:\/|$)/) {
+          $version =~ s/\D+$//;
+        }
+
         if ($entry !~ /^(?:.\/)?($name(?:-(?:v\.?)?$version)?)(?:\/|$)/) {
             warn "BOGUS PATH DETECTED: $entry\n";
             $bogus++;


### PR DESCRIPTION
Hi Steven,

Just a minor tweak to handle bad modules like Net::Daemon and PlRPC which don't include a version component in their top-level tarball directories (and which otherwise fail with BOGUS PATH warnings).

Thanks,
Gavin
