### PR TITLE
Several new features for even more usefulness

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -109,6 +109,10 @@ Force overwriting an existing spec file.  Normally B<cpanspec> will
 refuse to overwrite an existing spec file for safety.  This option
 removes that safety check.  Please use with caution.
 
+=item B<-S>, B<--stdout>
+
+Write the generated spec file to stdout instead of a file.
+
 =item B<-p>, B<--packager>
 
 The name and email address of the packager.  Overrides the C<%packager>
@@ -222,6 +226,7 @@ our $perl_version=0;
 our $addlicense=0;
 our $noprefix=0;
 our $force=0;
+our $stdout=0;
 our $packager;
 our $release=1;
 our $epoch;
@@ -539,6 +544,7 @@ GetOptions(
         'license|l'         => \$addlicense,
         'noprefix|n'        => \$noprefix,
         'force|f'           => \$force,
+        'stdout|S'          => \$stdout,
         'packager|p=s'      => \$packager,
         'release|r=i'       => \$release,
         'epoch|e=i'         => \$epoch,
@@ -817,7 +823,9 @@ for my $file (@args) {
     verbose "Writing $specfile...";
 
     my $spec;
-    if ($force) {
+    if ($stdout) {
+        $spec = *STDOUT;
+    } elsif ($force) {
         rename($specfile, "$specfile~") if (-e $specfile);
         $spec=new FileHandle ">$specfile";
     } else {


### PR DESCRIPTION
Hi Steven,

I'm using cpanspec a lot at work to generate RPMs for different perl versions. The patches in my fork made cpanspec even more useful for me, I hope you find them useful too. Here's a summary:

2c6340e Add an option to print the generated specfile to stdout
3b953c0 Allow building rpms for slightly older perl versions
1cd8735 Check all build requirements against CPAN
28dc8e9 Stop losing dependency version information
c406955 Strip any version comparison operator from the 'perl' build requirement
5516e78 Add entries from configure_requres in META.yml as build dependencies
38694a5 Detect scripts better
a84c283 Don't let Module::AutoInstall run interactively
b372334 Add a simple blacklisting mechanism

The only one that I think might be controversial is the blacklist, or at least the content of the proposed blacklist. The others make cpanspec generate correct specfiles more often. Of the 650+ packages I built, less than 10% needs a manual change when I use all the patches above.
