### PR TITLE
Escape slashes in filters

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -823,6 +823,7 @@ for my $file (@args) {
         }
         die "Failed to create $script: $!\n" if (!$sh);
 
+        map { s/\//\\\//g } @filter_requires;
         print $sh "#!/bin/sh\n\n"
             . "\@\@PERL_REQ\@\@ \"\$\@\" | sed -e '/^$filter_requires[0]\$/d'";
         if (@filter_requires > 1) {
@@ -845,6 +846,7 @@ for my $file (@args) {
         }
         die "Failed to create $script: $!\n" if (!$sh);
 
+        map { s/\//\\\//g } @filter_provides;
         print $sh "#!/bin/sh\n\n"
             . "\@\@PERL_PROV\@\@ \"\$\@\" | sed -e '/^$filter_provides[0]\$/d'";
         if (@filter_provides > 1) {


### PR DESCRIPTION
Simply escape slashes in --filter-requires and --filter-provides
options, resolving a five year old bug [0].

[0] https://bugzilla.redhat.com/show_bug.cgi?id=544738

Signed-off-by: Petr Šabata contyk@redhat.com
