### PR TITLE
Don't assume bin in %files from package files

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -882,7 +882,7 @@ for my $file (@args) {
 
     # TODO It's possible these need to be listed instead of just detected.
     my $uses_autoinstall = grep /Module\/AutoInstall.pm/, @files;
-    my $scripts=(grep /^(?:bin|scripts?|tools)\//, @files);
+    my $scripts=0;
     my $makecontent;
     if (grep /^Makefile\.PL$/, @files
         and $makecontent=extract($archive, $type, "$path/Makefile.PL")) {


### PR DESCRIPTION
Do not assume module has scripts to install just because the package ships with scripts/tools/bin folder(s). This causes most modules to include extra contents in the %files section:
%{_bindir}/*
%{_mandir}/man1/*
