### PR TITLE
Prefer dnf over repoquery if available

### DIFF
--- a/cpanspec
+++ b/cpanspec
@@ -537,10 +537,17 @@ sub check_rpm($) {
 sub check_repo($) {
     my $dep=shift;
 
-    my $repoquery=which("repoquery");
+    my ($repoquery, $repoqueryopts);
+    if (-x ($repoquery = which('dnf'))) {
+        $repoqueryopts = "whatprovides '${dep}'"
+    } elsif (-x ($repoquery = which('repoquery'))) {
+        $repoqueryopts = "--whatprovides '${dep}'"
+    } else {
+        return undef
+    }
 
     verbose("Running $repoquery to check for $dep.  This may take a while...");
-    my @out=`$repoquery --whatprovides "$dep"`;
+    my @out=`$repoquery $repoqueryopts 2>/dev/null`;
 
     if ($? != 0) {
         #warn "backtick (repoquery) failed with return value $?";


### PR DESCRIPTION
In Fedora, yum-utils are currently deprecated in favor of dnf.  This
change adds support for dnf to check_repo().

Signed-off-by: Petr Šabata contyk@redhat.com
